### PR TITLE
Bug Fix: $.ajax is not a function (Update package.json to reflect current wisebed.js Version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"main" : "wb.js",
 	"version" : "0.2.5",
 	"dependencies" : {
-		"wisebed.js"   : "0.2.4",
+		"wisebed.js"   : "0.2.5",
 		"commander"    : "2.0.0",
 		"moment"       : "2.8.3",
 		"btoa"         : "1.1.2",


### PR DESCRIPTION
Using wisebed.js version 0.2.4 does not work correctly, as it requires a jquery version above 1.8 and thus needs the fixes for $.ajax introduced in version 0.2.5.

Using 0.2.4 of wisebed.js leads to the following error:

```
            $.ajax({
              ^
TypeError: undefined is not a function
```
