### PR TITLE
Fix missleading reservationId parameter error

### DIFF
--- a/wb.js
+++ b/wb.js
@@ -351,7 +351,7 @@ function getReservationId(options) {
 function getAssertReservationId(options) {
 	var reservationId = getReservationId(options);
 	if (!reservationId) {
-		console.error('Parameter "-i,--reservationId" or environment variable WB_RESERVATION missing. Exiting.');
+		console.error('Reservation Id parameter "-i,--Id" or environment variable WB_RESERVATION missing. Exiting.');
 		process.exit(1);
 	}
 	return reservationId;
@@ -625,12 +625,6 @@ function executeFlash(options) {
 	var reservationId = getAssertReservationId(options);
 
 	var jsonConfig;
-
-	if (!reservationId) {
-		console.error('Parameter "reservationId" missing. Exiting.');
-		process.exit(1);
-	}
-
 	var createConfig;
 
 	if (options.file) {


### PR DESCRIPTION
The long parameter for the reservation id is defined as --Id but the error messages leads to an non existent --reservationId parameter.

Also `executeFlash` function checks the reservation parameter twice (once already in getAssertReservationId)
